### PR TITLE
fix: MySQL,MariaDB require defined column index length

### DIFF
--- a/src/Dbal/DocumentStore/DbalDocumentStore.php
+++ b/src/Dbal/DocumentStore/DbalDocumentStore.php
@@ -188,10 +188,15 @@ final class DbalDocumentStore implements DocumentStore
         $table->addColumn('document_type', Types::TEXT);
         $table->addColumn('document', Types::JSON);
 
-        if ($sm->getDatabasePlatform()->getName()) {
-            $table->addIndex(['collection', 'document_id'],null,[],["lengths"=>[255,255]]);
+        $columnNames=['collection', 'document_id'];
+        if ($sm->getDatabasePlatform()->getName()==='mysql') {
+            $table->addIndex($columnNames,null,[],["lengths"=>[255,255]]);
+            foreach ($columnNames as $columnName) {
+                $column = $table->getColumn($columnName);
+                $column->setNotnull(true);
+            }
         } else {
-            $table->setPrimaryKey(['collection', 'document_id']);
+            $table->setPrimaryKey($columnNames);
         }
 
         $sm->createTable($table);

--- a/src/Dbal/DocumentStore/DbalDocumentStore.php
+++ b/src/Dbal/DocumentStore/DbalDocumentStore.php
@@ -188,7 +188,11 @@ final class DbalDocumentStore implements DocumentStore
         $table->addColumn('document_type', Types::TEXT);
         $table->addColumn('document', Types::JSON);
 
-        $table->setPrimaryKey(['collection', 'document_id']);
+        if ($sm->getDatabasePlatform()->getName()) {
+            $table->addIndex(['collection', 'document_id'],null,[],["lengths"=>[255,255]]);
+        } else {
+            $table->setPrimaryKey(['collection', 'document_id']);
+        }
 
         $sm->createTable($table);
         $this->initialize = false;


### PR DESCRIPTION
**Error:**
`SQLSTATE[42000]: Syntax error or access violation: 1170 BLOB/TEXT column 'document_id' used in key specification without a key length`

Doctrine framework is not handling the problem and there is no public API to define a primary key with defined length.
https://github.com/doctrine/dbal/issues/5421

The current fix uses the doctrine api to create a unique index which has the option to define the length of the keys and set the columns to not allow NULL which is the difference between a primary key and a normal unique key.
