### PR TITLE
Add return types for DbalConfiguration class methods

### DIFF
--- a/src/DbalConnection.php
+++ b/src/DbalConnection.php
@@ -37,41 +37,65 @@ class DbalConnection implements ManagerRegistry
         return new ManagerRegistryConnectionFactory($managerRegistry, ['connection_name' => $connectionName]);
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getDefaultConnectionName(): string
     {
         return 'default';
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getConnection($name = null): object
     {
         return $this->connection;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getConnections(): array
     {
         return [$this->connection];
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getConnectionNames(): array
     {
         return ['default'];
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getDefaultManagerName(): string
     {
         return 'default';
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getManager($name = null): ObjectManager
     {
         return $this->entityManager;
     }
 
-    public function getManagers()
+    /**
+     * {@inheritdoc}
+     */
+    public function getManagers(): array
     {
         return $this->entityManager ? [$this->entityManager] : [];
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function resetManager($name = null): ObjectManager
     {
         $this->entityManager->getUnitOfWork()->clear();
@@ -79,21 +103,33 @@ class DbalConnection implements ManagerRegistry
         return $this->entityManager;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getAliasNamespace($alias): string
     {
         throw InvalidArgumentException::create('Method not supported');
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getManagerNames(): array
     {
         return ['default'];
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getRepository($persistentObject, $persistentManagerName = null): ObjectRepository
     {
         return $this->entityManager->getRepository($persistentObject);
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getManagerForClass($class): ?ObjectManager
     {
         return $this->entityManager;

--- a/src/DbalConnection.php
+++ b/src/DbalConnection.php
@@ -5,6 +5,8 @@ namespace Ecotone\Dbal;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectRepository;
 use Ecotone\Messaging\Support\InvalidArgumentException;
 use Enqueue\Dbal\DbalConnectionFactory;
 use Enqueue\Dbal\ManagerRegistryConnectionFactory;
@@ -35,32 +37,32 @@ class DbalConnection implements ManagerRegistry
         return new ManagerRegistryConnectionFactory($managerRegistry, ['connection_name' => $connectionName]);
     }
 
-    public function getDefaultConnectionName()
+    public function getDefaultConnectionName(): string
     {
         return 'default';
     }
 
-    public function getConnection($name = null)
+    public function getConnection($name = null): object
     {
         return $this->connection;
     }
 
-    public function getConnections()
+    public function getConnections(): array
     {
         return [$this->connection];
     }
 
-    public function getConnectionNames()
+    public function getConnectionNames(): array
     {
         return ['default'];
     }
 
-    public function getDefaultManagerName()
+    public function getDefaultManagerName(): string
     {
         return 'default';
     }
 
-    public function getManager($name = null)
+    public function getManager($name = null): ObjectManager
     {
         return $this->entityManager;
     }
@@ -70,29 +72,29 @@ class DbalConnection implements ManagerRegistry
         return $this->entityManager ? [$this->entityManager] : [];
     }
 
-    public function resetManager($name = null)
+    public function resetManager($name = null): ObjectManager
     {
         $this->entityManager->getUnitOfWork()->clear();
 
         return $this->entityManager;
     }
 
-    public function getAliasNamespace($alias)
+    public function getAliasNamespace($alias): string
     {
         throw InvalidArgumentException::create('Method not supported');
     }
 
-    public function getManagerNames()
+    public function getManagerNames(): array
     {
         return ['default'];
     }
 
-    public function getRepository($persistentObject, $persistentManagerName = null)
+    public function getRepository($persistentObject, $persistentManagerName = null): ObjectRepository
     {
         return $this->entityManager->getRepository($persistentObject);
     }
 
-    public function getManagerForClass($class)
+    public function getManagerForClass($class): ?ObjectManager
     {
         return $this->entityManager;
     }

--- a/src/DbalConnection.php
+++ b/src/DbalConnection.php
@@ -104,7 +104,7 @@ class DbalConnection implements ManagerRegistry
     }
 
     /**
-     * {@inheritdoc}
+     * @throws InvalidArgumentException
      */
     public function getAliasNamespace($alias): string
     {


### PR DESCRIPTION
Remove Symfony indirect deprecation notices in integrations tests:

 1x: Method "Doctrine\Persistence\ConnectionRegistry::getDefaultConnectionName()" might add "string" as a native return type declaration in the future. Do the same in implementation "Ecotone\Dbal\DbalConnection" now to avoid errors or add an explicit @return annotation to suppress this message.

  1x: Method "Doctrine\Persistence\ConnectionRegistry::getConnection()" might add "object" as a native return type declaration in the future. Do the same in implementation "Ecotone\Dbal\DbalConnection" now to avoid errors or add an explicit @return annotation to suppress this message.

  1x: Method "Doctrine\Persistence\ConnectionRegistry::getConnections()" might add "array" as a native return type declaration in the future. Do the same in implementation "Ecotone\Dbal\DbalConnection" now to avoid errors or add an explicit @return annotation to suppress this message.

  1x: Method "Doctrine\Persistence\ConnectionRegistry::getConnectionNames()" might add "array" as a native return type declaration in the future. Do the same in implementation "Ecotone\Dbal\DbalConnection" now to avoid errors or add an explicit @return annotation to suppress this message.

  1x: Method "Doctrine\Persistence\ManagerRegistry::getDefaultManagerName()" might add "string" as a native return type declaration in the future. Do the same in implementation "Ecotone\Dbal\DbalConnection" now to avoid errors or add an explicit @return annotation to suppress this message.

  1x: Method "Doctrine\Persistence\ManagerRegistry::getManager()" might add "ObjectManager" as a native return type declaration in the future. Do the same in implementation "Ecotone\Dbal\DbalConnection" now to avoid errors or add an explicit @return annotation to suppress this message.

  1x: Method "Doctrine\Persistence\ManagerRegistry::getManagers()" might add "array" as a native return type declaration in the future. Do the same in implementation "Ecotone\Dbal\DbalConnection" now to avoid errors or add an explicit @return annotation to suppress this message.

  1x: Method "Doctrine\Persistence\ManagerRegistry::resetManager()" might add "ObjectManager" as a native return type declaration in the future. Do the same in implementation "Ecotone\Dbal\DbalConnection" now to avoid errors or add an explicit @return annotation to suppress this message.

  1x: Method "Doctrine\Persistence\ManagerRegistry::getAliasNamespace()" might add "string" as a native return type declaration in the future. Do the same in implementation "Ecotone\Dbal\DbalConnection" now to avoid errors or add an explicit @return annotation to suppress this message.

  1x: Method "Doctrine\Persistence\ManagerRegistry::getManagerNames()" might add "array" as a native return type declaration in the future. Do the same in implementation "Ecotone\Dbal\DbalConnection" now to avoid errors or add an explicit @return annotation to suppress this message.

  1x: Method "Doctrine\Persistence\ManagerRegistry::getRepository()" might add "ObjectRepository" as a native return type declaration in the future. Do the same in implementation "Ecotone\Dbal\DbalConnection" now to avoid errors or add an explicit @return annotation to suppress this message.

  1x: Method "Doctrine\Persistence\ManagerRegistry::getManagerForClass()" might add "?ObjectManager" as a native return type declaration in the future. Do the same in implementation "Ecotone\Dbal\DbalConnection" now to avoid errors or add an explicit @return annotation to suppress this message.