### PR TITLE
handle update of identical content

### DIFF
--- a/src/DocumentStore/DbalDocumentStore.php
+++ b/src/DocumentStore/DbalDocumentStore.php
@@ -51,12 +51,14 @@ final class DbalDocumentStore implements DocumentStore
                     'document_id' => $documentId,
                     'document_type' => $type->toString(),
                     'document' => $this->convertToJSONDocument($type, $document),
+                    'updated_at' => hrtime(true),
                 ],
                 [
                     'collection' => Types::STRING,
                     'document_id' => Types::STRING,
                     'document_type' => Types::STRING,
                     'document' => Types::TEXT,
+                    'updated_at' => Types::FLOAT,
                 ]
             );
         } catch (DriverException $driverException) {
@@ -196,6 +198,7 @@ final class DbalDocumentStore implements DocumentStore
         $table->addColumn('document_id', Types::STRING);
         $table->addColumn('document_type', Types::TEXT);
         $table->addColumn('document', Types::JSON);
+        $table->addColumn('updated_at', Types::FLOAT, ["length"=>53]);
 
         $table->setPrimaryKey(['collection', 'document_id']);
 
@@ -246,6 +249,7 @@ final class DbalDocumentStore implements DocumentStore
                 [
                     'document_type' => $type->toString(),
                     'document' => $this->convertToJSONDocument($type, $document),
+                    'updated_at' => hrtime(true),
                 ],
                 [
                     'document_id' => $documentId,
@@ -256,6 +260,7 @@ final class DbalDocumentStore implements DocumentStore
                     'document_id' => Types::STRING,
                     'document_type' => Types::STRING,
                     'document' => Types::STRING,
+                    'updated_at' => Types::FLOAT,
                 ]
             );
         } catch (DriverException $driverException) {

--- a/tests/DocumentStore/DbalDocumentStoreTest.php
+++ b/tests/DocumentStore/DbalDocumentStoreTest.php
@@ -59,6 +59,18 @@ final class DbalDocumentStoreTest extends DbalMessagingTest
         $this->assertJsons('{"name":"Franco"}', $documentStore->getDocument('users', '123'));
     }
 
+    public function test_updating_document_with_same_content()
+    {
+        $documentStore = $this->getDocumentStore();
+
+        $this->assertEquals(0, $documentStore->countDocuments('users'));
+
+        $documentStore->addDocument('users', '123', '{"name":"Johny"}');
+        $documentStore->updateDocument('users', '123', '{"name":"Johny"}');
+
+        $this->assertJsons('{"name":"Johny"}', $documentStore->getDocument('users', '123'));
+    }
+
     public function test_adding_document_as_object_should_return_object()
     {
         $documentStore = new DbalDocumentStore(


### PR DESCRIPTION
fix [Documentstore / updateDocument / throws DocumentNotFound if the new document is identical to the existing document](https://github.com/ecotoneframework/ecotone-dev/issues/37)